### PR TITLE
Testing PR ICU-22233 Fix CI cache name for Bazel build

### DIFF
--- a/.github/workflows/icu_ci.yml
+++ b/.github/workflows/icu_ci.yml
@@ -490,11 +490,15 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - uses: bazelbuild/setup-bazelisk@v1
+    - name: Get CI Linux runner VM version
+      id: linux-version
+      run: |
+        echo "LINUX_VERSION=$(grep -F VERSION_ID /etc/os-release | cut -d'"' -f2)" >> $GITHUB_OUTPUT
     - name: Mount bazel cache
       uses: actions/cache@v2
       with:
         path: "~/.cache/bazel"
-        key: ${{ runner.os }}-bazel
+        key: bazel-${{ runner.os }}-${{ steps.linux-version.outputs.LINUX_VERSION }}
 
     - name: Generate the data
       run: |


### PR DESCRIPTION
To test whether the cache name ends up being the image name `ubuntu-22.04`, which is appropriately specific and originally intended, instead of the the current OS name `Linux`.

<!--
Thank you for your pull request!

Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license agreement (CLA) before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html
-->

##### Checklist

- [ ] Required: Issue filed: https://unicode-org.atlassian.net/browse/ICU-_____
- [ ] Required: The PR title must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [ ] Required: The PR description must include the link to the Jira Issue, for example by completing the URL in the first checklist item
- [ ] Required: Each commit message must be prefixed with a JIRA Issue number. <!-- For example: "ICU-1234 Fix xyz" -->
- [ ] Issue accepted (done by Technical Committee after discussion)
- [ ] Tests included, if applicable
- [ ] API docs and/or User Guide docs changed or added, if applicable
